### PR TITLE
Changed 'superlists/superlists' to 'superlists'

### DIFF
--- a/chapter_unit_test_first_view.asciidoc
+++ b/chapter_unit_test_first_view.asciidoc
@@ -435,7 +435,7 @@ urls.py
 ((("URL mappings")))Our
 tests are telling us that we need a URL mapping. Django uses a file called
 'urls.py' to map URLs to view functions. There's a main 'urls.py' for the whole
-site in the 'superlists/superlists' folder. Let's go take a look:
+site in the 'superlists' folder. Let's go take a look:
 
 
 [role="sourcecode currentcontents"]


### PR DESCRIPTION
I think this was a holdover from v1 of the book before `django-admin.py startproject superlists .` was added to the prerequisites section of v2.